### PR TITLE
added latex output generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:edge
 COPY entrypoint.sh /entrypoint.sh
 
 # Install required packages
-RUN apk add doxygen graphviz ttf-freefont
+RUN apk add doxygen graphviz ttf-freefont doxygen-latex perl build-base
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,5 @@ FROM alpine:edge
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 
-# Install required packages
-RUN apk add doxygen graphviz ttf-freefont perl build-base texlive-full biblatex
-
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:edge
 COPY entrypoint.sh /entrypoint.sh
 
 # Install required packages
-RUN apk add doxygen graphviz ttf-freefont perl build-base texlive biblatex
+RUN apk add doxygen graphviz ttf-freefont perl build-base texlive-full biblatex
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:edge
 COPY entrypoint.sh /entrypoint.sh
 
 # Install required packages
-RUN apk add doxygen graphviz ttf-freefont doxygen-latex perl build-base
+RUN apk add doxygen graphviz ttf-freefont perl build-base texlive biblatex
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actio
 ### 'doxyfile-path'
 **Required** Path of the Doxyfile relative to the working directory. Default: `./Doxyfile`.
 ### 'enable-latex'
-**Optional** true: enable make for LaTeX part of doxygen output. Default: `false`.
+**Optional** Flag to enable `make`-ing of the LaTeX part of the doxygen output. Default: `false`.
 
 ## Example usage (no LaTeX)
 ```yaml

--- a/README.md
+++ b/README.md
@@ -10,11 +10,22 @@ Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actio
 **Required** Path of the working directory to change to before running doxygen. Default: `.`
 ### 'doxyfile-path'
 **Required** Path of the Doxyfile relative to the working directory. Default: `./Doxyfile`.
+### 'enable-latex'
+**Optional** true: enable make for LaTeX part of doxygen output. Default: `false`.
 
-## Example usage
+## Example usage (no LaTeX)
 ```yaml
 uses: mattnotmitt/doxygen-action@v1
 with:
     working-directory: 'submodule/'
     doxyfile-path: 'docs/Doxygen'
+```
+
+## Example usage (with LaTeX)
+```yaml
+uses: mattnotmitt/doxygen-action@v1
+with:
+    working-directory: 'submodule/'
+    doxyfile-path: 'docs/Doxygen'
+    enable-latex: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,14 @@ inputs:
     description: 'Working directory'
     required: true
     default: '.'
+  enable-latex:
+    description: 'Generate latex documentation'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.doxyfile-path }}
     - ${{ inputs.working-directory }}
+    - ${{ inputs.enable-latex }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,3 +9,7 @@ if [ ! -f $1 ]; then
 fi
 
 doxygen $1
+
+# latex
+cd $2/docs/latex
+make

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# execute doxygen
+# $1 is the path to the Doxyfile
+# $2 is the directory where doxygen should be executed
+# $3 is a boolean: true -> enable latex generation, false -> skip latex generation
+
 if [ ! -d $2 ]; then
     echo "Path $2 could not be found!"
 fi
@@ -8,8 +14,22 @@ if [ ! -f $1 ]; then
     echo "File $1 could not be found!"
 fi
 
+# install packages; add latex-related packages only if enabled
+PACKAGES="doxygen graphviz ttf-freefont"
+if [ ! -z $3 ] ; then
+  if [ "$3" = true ] ; then
+    PACKAGES="$PACKAGES perl build-base texlive-full biblatex"
+  fi
+fi
+apk add $PACKAGES
+
+# run "regular" doxygen
 doxygen $1
 
-# latex
-cd $2/docs/latex
-make
+# if enabled, make latex pdf output
+if [ ! -z $3 ] ; then
+  if [ "$3" = true ] ; then
+    cd $2/docs/latex
+    make
+  fi
+fi


### PR DESCRIPTION
Hi @mattnotmitt ,
I added the required packages for generating the `latex` documentation part as well as a call to `make` to build them.
Coming to think of it, I think this feature should be made optional, since not all users might want to enable the `latex` functionality of `doxygen` at all. What do you think?
Cheers,
 Jonathan
