### PR TITLE
Adds support to fail on warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actio
 **Required** Path of the Doxyfile relative to the working directory. Default: `./Doxyfile`.
 ### 'enable-latex'
 **Optional** Flag to enable `make`-ing of the LaTeX part of the doxygen output. Default: `false`.
+### 'fail-on-warnings'
+**Not Required** Make this action fail if doxygen produces warnings. Will print the warnings if this value is set to 'TRUE'. Default: 'FALSE'. 
 
 ## Example usage (no LaTeX)
 ```yaml

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actio
 ### 'enable-latex'
 **Optional** Flag to enable `make`-ing of the LaTeX part of the doxygen output. Default: `false`.
 ### 'fail-on-warnings'
-**Not Required** Make this action fail if doxygen produces warnings. Will print the warnings if this value is set to 'TRUE'. Default: 'FALSE'. 
+**Not Required** Make this action fail if doxygen produces warnings. Will print the warnings if this value is set to `TRUE`. Default: `FALSE`. 
+### 'warnings-filter'
+**Not Required** Enables a filter for the warnings relevant to fail-on-warnings. Matching lines will be filtered out using grep. If this value is empty, no filter is applied. Default: empty string.
 
 ## Example usage (no LaTeX)
 ```yaml
@@ -21,6 +23,8 @@ uses: mattnotmitt/doxygen-action@v1
 with:
     working-directory: 'submodule/'
     doxyfile-path: 'docs/Doxygen'
+    fail-on-warnings: 'TRUE'
+    warnings-filter: 'stupid-warning-I-want-to-ignore'
 ```
 
 ## Example usage (with LaTeX)

--- a/README.md
+++ b/README.md
@@ -34,4 +34,6 @@ with:
     working-directory: 'submodule/'
     doxyfile-path: 'docs/Doxygen'
     enable-latex: true
+    fail-on-warnings: 'TRUE'
+    warnings-filter: 'stupid-warning-I-want-to-ignore'
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actio
 ### 'enable-latex'
 **Optional** Flag to enable `make`-ing of the LaTeX part of the doxygen output. Default: `false`.
 ### 'fail-on-warnings'
-**Not Required** Make this action fail if doxygen produces warnings. Will print the warnings if this value is set to `TRUE`. Default: `FALSE`. 
+**Not Required** Make this action fail if doxygen produces warnings. Will print the warnings if this value is set to `true`. Default: `false`. 
 ### 'warnings-filter'
 **Not Required** Enables a filter for the warnings relevant to fail-on-warnings. Matching lines will be filtered out using grep. If this value is empty, no filter is applied. Default: empty string.
 
@@ -23,7 +23,7 @@ uses: mattnotmitt/doxygen-action@v1
 with:
     working-directory: 'submodule/'
     doxyfile-path: 'docs/Doxygen'
-    fail-on-warnings: 'TRUE'
+    fail-on-warnings: true
     warnings-filter: 'stupid-warning-I-want-to-ignore'
 ```
 
@@ -34,6 +34,6 @@ with:
     working-directory: 'submodule/'
     doxyfile-path: 'docs/Doxygen'
     enable-latex: true
-    fail-on-warnings: 'TRUE'
+    fail-on-warnings: true
     warnings-filter: 'stupid-warning-I-want-to-ignore'
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Generate latex documentation'
     required: false
     default: false
+  fail-on-warnings:
+    description: 'Make this action fail if doxygen produces warnings.'
+    required: false
+    default: 'FALSE'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -23,3 +27,4 @@ runs:
     - ${{ inputs.doxyfile-path }}
     - ${{ inputs.working-directory }}
     - ${{ inputs.enable-latex }}
+    - ${{ inputs.fail-on-warnings }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Make this action fail if doxygen produces warnings.'
     required: false
     default: 'FALSE'
+  warnings-filter:
+    description: 'Warning filter, matching lines will be filtered out.'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -28,3 +32,4 @@ runs:
     - ${{ inputs.working-directory }}
     - ${{ inputs.enable-latex }}
     - ${{ inputs.fail-on-warnings }}
+    - ${{ inputs.warnings-filter }}

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,11 @@ branding:
 inputs:
   doxyfile-path:
     description: 'Path to Doxyfile'
-    required: true
+    required: false
     default: './Doxyfile'
   working-directory:
     description: 'Working directory'
-    required: true
+    required: false
     default: '.'
   enable-latex:
     description: 'Generate latex documentation'

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   fail-on-warnings:
     description: 'Make this action fail if doxygen produces warnings.'
     required: false
-    default: 'FALSE'
+    default: false
   warnings-filter:
     description: 'Warning filter, matching lines will be filtered out.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,7 @@ apk add $PACKAGES
 # Tests if the $4 is either 'true' or 'false'.
 if [ ! -z $4 ]; then
     echo "Failing on warnings is enabled."
-    FAIL_ON_WARNINGS=1
+    FAIL_ON_WARNINGS=true
 else
     echo "Failing on warnings disabled."
     FAIL_ON_WARNINGS=0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,19 +31,16 @@ fi
 apk add $PACKAGES
 
 
-# Tests if the third argument is either 'TRUE' or 'FALSE'. Produces warning if neither is set.
-if [ "$4" = "TRUE" ]; then
+# Tests if the $4 is either 'true' or 'false'.
+if [ ! -z $4 ]; then
     echo "Failing on warnings is enabled."
-    fail_on_warnings=true
-elif [ "$4" = "FALSE" ]; then
-    echo "Failing on warnings disabled."
-    fail_on_warnings=false
+    FAIL_ON_WARNINGS=true
 else
-    echo "Unknown value for fail-on-warnings. Should be either 'FALSE' or 'TRUE'."
-    exit 1
+    echo "Failing on warnings disabled."
+    FAIL_ON_WARNINGS=false
 fi
 
-if [ "$fail_on_warnings" = true ]; then
+if [ "$FAIL_ON_WARNINGS" = true ]; then
     doxygen $1 2> warnings.txt
 
     # if $5 is non-empty, apply filter.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,8 @@
 # $1 is the path to the Doxyfile
 # $2 is the directory where doxygen should be executed
 # $3 is a boolean: true -> enable latex generation, false -> skip latex generation
+# $4 is a boolean: true -> fail on warnings, except those in $5, false -> only fail if error
+# $5 is a string: grep syntax
 
 if [ ! -d $2 ]; then
     echo "Path $2 could not be found!"
@@ -34,10 +36,10 @@ apk add $PACKAGES
 # Tests if the $4 is either 'true' or 'false'.
 if [ ! -z $4 ]; then
     echo "Failing on warnings is enabled."
-    FAIL_ON_WARNINGS=true
+    FAIL_ON_WARNINGS=1
 else
     echo "Failing on warnings disabled."
-    FAIL_ON_WARNINGS=false
+    FAIL_ON_WARNINGS=0
 fi
 
 if [ "$FAIL_ON_WARNINGS" = true ]; then
@@ -67,7 +69,6 @@ if [ "$FAIL_ON_WARNINGS" = true ]; then
 else
   doxygen $1
 fi
-
 
 # if enabled, make latex pdf output
 if [ "$BUILD_LATEX" = true ] ; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,6 +45,19 @@ fi
 
 if [ "$fail_on_warnings" = true ]; then
     doxygen $1 2> warnings.txt
+
+    # if $5 is non-empty, apply filter.
+    if [ ! -z "$5" ]; then
+      grep "$5" warnings.txt > filtered-out-warnings.txt
+      filtered_amount=$(cat filtered-out-warnings.txt | wc -l)
+      printf "Total amount of filtered-out doxygen errors and warnings: '%d'\n"  "$filtered_amount"
+      echo "Filtered-out warnings:"
+      cat filtered-out-warnings.txt
+      grep -v "$5" warnings.txt > warnings-filtered.txt
+      mv warnings-filtered.txt warnings.txt
+    else
+      echo "No filter specified, not filtering any warnings."
+    fi
     problems_amount=$(cat warnings.txt | wc -l)
     printf "Total amount of doxygen errors and warnings: '%d'\n"  "$problems_amount"
     if [ $problems_amount -ne 0 ] ; then


### PR DESCRIPTION
Adds support to fail on warnings.
These warnings can be filtered by a regex using grep.
Filtered and remaining warnings will be printed and the step will be set as failing iff no un-filtered warnings remain.

This adds the options 
```yaml
  fail-on-warnings:
    description: 'Make this action fail if doxygen produces warnings.'
    required: false
    default: false
  warnings-filter:
    description: 'Warning filter, matching lines will be filtered out.'
    required: false
    default: ''
```

The old behavior is kept and failure on warnings is only enabled if fail-on-warnings is set to true.