### PR TITLE
Add ghostscript for pdflatex

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 PACKAGES="doxygen graphviz ttf-freefont"
 if [ "$BUILD_LATEX" = true ] ; then
-  PACKAGES="$PACKAGES perl build-base texlive-full biblatex"
+  PACKAGES="$PACKAGES perl build-base texlive-full biblatex ghostscript"
 fi
 apk add $PACKAGES
 


### PR DESCRIPTION
Add ghostscript to the installed packages. This keeps pdflatex builds from failing when converting class diagrams using the epstopdf package.