### PR TITLE
Feature additional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,31 @@
 # Doxygen Docker Action
+
 This [GitHub Action](https://github.com/features/actions) will build [doxygen](http://doxygen.nl/) docs from the specified doxyfile.
 
 Use with an action such as [actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) to deploy to your project's GitHub pages site!
 
-**NOTE:** If you are using dot/graphviz in your doxygen config to generate diagrams the only fonts installed, and hence can be used are those in the [GNU FreeFont](https://www.gnu.org/software/freefont/) package (FreeSans, FreeMono and FreeSerif).
+**NOTE:** If you are using dot/graphviz in your doxygen config to generate diagrams the only fonts installed, and hence can be used are those in the [GNU FreeFont](https://www.gnu.org/software/freefont/) package (FreeSans, FreeMono and FreeSerif) or in any package listed in `additional-packages`.
 
 ## Inputs
+
 ### 'working-directory'
+
 **Required** Path of the working directory to change to before running doxygen. Default: `.`
+
 ### 'doxyfile-path'
+
 **Required** Path of the Doxyfile relative to the working directory. Default: `./Doxyfile`.
+
 ### 'enable-latex'
+
 **Optional** Flag to enable `make`-ing of the LaTeX part of the doxygen output. Default: `false`.
 
+### 'additional-packages'
+
+**Optional** Additional alpine packages to install in the environment (i.e. font packages)
+
 ## Example usage (no LaTeX)
+
 ```yaml
 uses: mattnotmitt/doxygen-action@v1
 with:
@@ -22,6 +34,7 @@ with:
 ```
 
 ## Example usage (with LaTeX)
+
 ```yaml
 uses: mattnotmitt/doxygen-action@v1
 with:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Generate latex documentation'
     required: false
     default: false
+  additional-packages:
+    description: 'Extra alpine packages for the build environment'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -23,3 +27,4 @@ runs:
     - ${{ inputs.doxyfile-path }}
     - ${{ inputs.working-directory }}
     - ${{ inputs.enable-latex }}
+    - ${{ inputs.additional-packages }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,14 +4,15 @@
 # $1 is the path to the Doxyfile
 # $2 is the directory where doxygen should be executed
 # $3 is a boolean: true -> enable latex generation, false -> skip latex generation
+# $4 is a string with extra alpine packages to be installed (i.e. font-fira-code)
 
 if [ ! -d $2 ]; then
-    echo "Path $2 could not be found!"
+  echo "Path $2 could not be found!"
 fi
 cd $2
 
 if [ ! -f $1 ]; then
-    echo "File $1 could not be found!"
+  echo "File $1 could not be found!"
 fi
 
 # install packages; add latex-related packages only if enabled
@@ -22,7 +23,7 @@ else
   BUILD_LATEX=0
 fi
 
-PACKAGES="doxygen graphviz ttf-freefont"
+PACKAGES="doxygen graphviz ttf-freefont $4"
 if [ "$BUILD_LATEX" = true ] ; then
   PACKAGES="$PACKAGES perl build-base texlive-full biblatex ghostscript"
 fi


### PR DESCRIPTION
Hello everyone

I want to use different fonts when exporting graphs with dot, but I have not managed to correctly use the `DOT_FONTPATH` configuration (I suspect it is broken due to [fontconfig use](https://graphviz.org/faq/#FaqFontNotFound) in newer versions of graphviz). So, it is necessary to install custom fonts system-wide in order to generate graphs with them.

The solution I took is to create an additional argument in the configuration of the action, allowing users to specify alpine font packages to be installed and then used by dot. Letting users install arbitrary packages is not the smartest idea in terms of security concerns, but it may not be a major problem in our case.

With this modification I was able to install [Fira Code package for Alpine](https://pkgs.alpinelinux.org/package/edge/testing/x86/font-fira-code) and generate graphs with it