### PR TITLE
updates to fix missing `psfonts.map` file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM debian:stable
+FROM archlinux:base
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM alpine:edge
+FROM debian:stable
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: false
   additional-packages:
-    description: 'Extra alpine packages for the build environment'
+    description: 'Extra packages for the build environment'
     required: false
     default: ''
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,12 +23,12 @@ else
   BUILD_LATEX=0
 fi
 
-apt-get update
-PACKAGES="doxygen graphviz fonts-freefont-ttf $4"
+pacman --noconfirm -Syu
+PACKAGES="doxygen graphviz gnu-free-fonts $4"
 if [ "$BUILD_LATEX" = true ] ; then
-  PACKAGES="$PACKAGES perl build-essential texlive-full ghostscript"
+  PACKAGES="$PACKAGES perl base-devel texlive-most ghostscript"
 fi
-apt-get install -y $PACKAGES
+pacman --noconfirm -S $PACKAGES
 
 # run "regular" doxygen
 doxygen $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ else
   BUILD_LATEX=0
 fi
 
+apt-get update
 PACKAGES="doxygen graphviz fonts-freefont-ttf $4"
 if [ "$BUILD_LATEX" = true ] ; then
   PACKAGES="$PACKAGES perl build-essential texlive-full ghostscript"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 
 PACKAGES="doxygen graphviz ttf-freefont $4"
 if [ "$BUILD_LATEX" = true ] ; then
-  PACKAGES="$PACKAGES perl build-base texlive-full biblatex ghostscript"
+  PACKAGES="$PACKAGES perl build-base texlive-full biblatex ghostscript texlive-updmap-map"
 fi
 apk add $PACKAGES
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,7 +28,7 @@ PACKAGES="doxygen graphviz fonts-freefont-ttf $4"
 if [ "$BUILD_LATEX" = true ] ; then
   PACKAGES="$PACKAGES perl build-essential texlive-full ghostscript"
 fi
-apt-get install $PACKAGES
+apt-get install -y $PACKAGES
 
 # run "regular" doxygen
 doxygen $1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@
 # $1 is the path to the Doxyfile
 # $2 is the directory where doxygen should be executed
 # $3 is a boolean: true -> enable latex generation, false -> skip latex generation
-# $4 is a string with extra alpine packages to be installed (i.e. font-fira-code)
+# $4 is a string with extra packages to be installed (i.e. font-fira-code)
 
 if [ ! -d $2 ]; then
   echo "Path $2 could not be found!"
@@ -23,11 +23,11 @@ else
   BUILD_LATEX=0
 fi
 
-PACKAGES="doxygen graphviz ttf-freefont $4"
+PACKAGES="doxygen graphviz fonts-freefont-ttf $4"
 if [ "$BUILD_LATEX" = true ] ; then
-  PACKAGES="$PACKAGES perl build-base texlive-full biblatex ghostscript texlive-updmap-map"
+  PACKAGES="$PACKAGES perl build-essential texlive-full ghostscript"
 fi
-apk add $PACKAGES
+apt-get install $PACKAGES
 
 # run "regular" doxygen
 doxygen $1


### PR DESCRIPTION
Hi Matt,

I recently got the following error at the end of running LaTeX on the doxygen output:
```
kpathsea: Running mktexpk --mfmode / --bdpi 600 --mag 0+486/600 --dpi 486 phvbo8r
gsftopk: fatal: map file `psfonts.map' not found.
mktexpk: don't know how to create bitmap font for phvbo8r.
mktexpk: perhaps phvbo8r is missing from the map file.
kpathsea: Appending font creation commands to missfont.log.
-var/fonts/pk/ljfour/public/latex-fonts/line10.600pk>
make: *** [Makefile:8: refman.pdf] Error 1
!pdfTeX error: pdflatex (file phvbo8r): Font phvbo8r at 486 not found
 ==> Fatal error occurred, no output PDF file produced!
```

I don't know which package I would have to install on alpine to get `psfonts.map` and so I (temporarily ?) switched to Arch Linux, where I know that doxygen+LaTeX still works.

Could you please have a look if you can make `psfonts.map` available in your docker setup and/or let me know if you have objections against switching to Arch?

Thanks,
 Jonathan